### PR TITLE
SW-7034 Make use of the new API version

### DIFF
--- a/airbyte-integrations/connectors/source-doordash/integration_tests/state.json
+++ b/airbyte-integrations/connectors/source-doordash/integration_tests/state.json
@@ -1,6 +1,6 @@
 {
     "order_details": {
-      "ACTIVE_DATE": "2023-04-10"
+      "ACTIVE_DATE": "2024-09-25"
     },
     "transaction_details": {
       "TIMESTAMP_LOCAL_DATE": "2023-04-10"

--- a/airbyte-integrations/connectors/source-doordash/source_doordash/schemas/order_details.json
+++ b/airbyte-integrations/connectors/source-doordash/source_doordash/schemas/order_details.json
@@ -72,6 +72,21 @@
     },
     "SUBTOTAL": {
       "type": ["null", "number"]
-    }       
+    },
+    "ORDER_CART_ID": {
+      "type": ["null", "string"]
+    },
+    "ORDER_PLACE_DATE": {
+      "type": ["null", "string"]
+    },    
+    "ORDER_PLACE_TIME": {
+      "type": ["null", "string"]
+    },
+    "CREATED_AT": {
+      "type": ["null", "string"]
+    },
+    "UPDATED_AT": {
+      "type": ["null", "string"]
+    }
   }
 }

--- a/airbyte-integrations/connectors/source-doordash/source_doordash/source.py
+++ b/airbyte-integrations/connectors/source-doordash/source_doordash/source.py
@@ -73,6 +73,11 @@ class IncrementalDoordashStream(DoordashStream):
             "end_date": end_date,
             "report_type": self.report_type
         }
+        
+        # Only use API v2 for ORDER_DETAIL.
+        if self.report_type == "ORDER_DETAIL":
+            request_json["report_version"] = 2
+
         self.logger.info(f"Sending request: {request_json}")
         return request_json
     
@@ -156,7 +161,8 @@ class SourceDoordash(AbstractSource):
                 "store_ids": [],
                 "start_date": "2023-01-01",
                 "end_date": "2023-01-02",
-                "report_type": "ORDER_DETAIL"
+                "report_type": "ORDER_DETAIL",
+                "report_version": 2
             }
             response = requests.post(url_base, headers=auth.get_auth_header(), json=body)
             response.raise_for_status()


### PR DESCRIPTION
Order date/time is now available directly from the order details feed, eliminating the need to do order ID fuzzy matching.